### PR TITLE
Anonymous structs

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ func main() {
 
 	t := phidgets.PhidgetTemperatureSensor{}
 	t.Create()
-	//t.SetIsRemote(true)
-	//t.SetDeviceSerialNumber(597101)
-	//t.SetHubPort(0)
-	if err := t.OpenWaitForAttachment(2000); err != nil {
+	t.SetIsRemote(true)
+	t.SetDeviceSerialNumber(597101)
+	t.SetHubPort(0)
+	if err := t.OpenWaitForAttachment(time.Second * 2); err != nil {
 		panic(err)
 	}
 	if err := t.SetOnTemperatureChangeHandler(func(val float64) {
@@ -34,7 +34,7 @@ func main() {
 	h.SetIsRemote(true)
 	h.SetDeviceSerialNumber(597101)
 	h.SetHubPort(0)
-	if err := h.OpenWaitForAttachment(2000); err != nil {
+	if err := h.OpenWaitForAttachment(time.Second * 2); err != nil {
 		panic(err)
 	}
 	h.SetOnHumidityChangeHandler(func(value float64) {
@@ -54,7 +54,7 @@ func main() {
 	lcd.SetHubPort(5)
 	lcd.SetIsRemote(true)
 	lcd.SetBacklight(.55)
-	if err := lcd.OpenWaitForAttachment(2000); err != nil {
+	if err := lcd.OpenWaitForAttachment(time.Second * 2); err != nil {
 		panic(err)
 	}
 
@@ -65,7 +65,7 @@ func main() {
 				val, _ := s.GetValue()
 				val = val*9.0/5.0 + 32
 				fmt.Printf("Temperature is %f Fahrenheit\n", val)
-				//lcd.SetText(fmt.Sprintf("Justin: %f", val))
+				lcd.SetText(fmt.Sprintf("Justin: %f", val))
 			case *phidgets.PhidgetHumiditySensor:
 				hum, _ := s.GetValue()
 				fmt.Println("Humidity is", hum)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/jrcichra/gophidgets/phidgets"
@@ -76,8 +75,7 @@ func main() {
 
 	//Close the sensors
 	for _, sensor := range sensors {
-		s := sensor.(io.Closer)
-		s.Close()
+		sensor.Close()
 	}
 
 	lcd.Close()

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	//Array of generic phidget sensors
-	sensors := make([]interface{}, 0)
+	sensors := make([]phidgets.Phidget, 0)
 
 	phidgets.AddServer("Justin", "10.0.0.176", 5661, "", 0)
 

--- a/phidgets/accelerometer.go
+++ b/phidgets/accelerometer.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetAccelerometer is the struct that is a phidget motion sensor
 type PhidgetAccelerometer struct {
-	Phidget
+	phidget
 	handle C.PhidgetAccelerometerHandle
 }
 
@@ -155,7 +155,7 @@ func (p *PhidgetAccelerometer) SetOnAccelerationChangeHandler(f func([]float64, 
 
 //Close - close the handle and delete it
 func (p *PhidgetAccelerometer) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetAccelerometer_delete(&p.handle))

--- a/phidgets/accelerometer.go
+++ b/phidgets/accelerometer.go
@@ -10,93 +10,87 @@ void ccallback(void* handle, void* ctx, const double acceleration[3], double tim
 */
 import "C"
 import (
-	"errors"
-	"reflect"
-	"unsafe"
-
 	gopointer "github.com/mattn/go-pointer"
+	"unsafe"
 )
 
 //PhidgetAccelerometer is the struct that is a phidget motion sensor
 type PhidgetAccelerometer struct {
+	Phidget
 	handle C.PhidgetAccelerometerHandle
 }
 
 //Create creates a phidget motion sensor
 func (p *PhidgetAccelerometer) Create() {
 	C.PhidgetAccelerometer_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetAcceleration gets the acceleration from a phidget motion sensor
-func (p *PhidgetAccelerometer) GetAcceleration() ([]float32, error) {
+func (p *PhidgetAccelerometer) GetAcceleration() ([]float64, error) {
 	var r [3]C.double
 	cerr := C.PhidgetAccelerometer_getAcceleration(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return nil, errors.New(p.getErrorDescription(cerr))
+		return nil, p.phidgetError(cerr)
 	}
-	var ret []float32 = []float32{ (float32)(r[0]), (float32)(r[1]), (float32)(r[2]) }
+	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
 	return ret, nil
 }
 
 //GetMinAcceleration gets the min acceleration value from a phidget motion sensor
-func (p *PhidgetAccelerometer) GetMinAcceleration() ([]float32, error) {
+func (p *PhidgetAccelerometer) GetMinAcceleration() ([]float64, error) {
 	var r [3]C.double
 	cerr := C.PhidgetAccelerometer_getMinAcceleration(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return nil, errors.New(p.getErrorDescription(cerr))
+		return nil, p.phidgetError(cerr)
 	}
-	var ret []float32 = []float32{ (float32)(r[0]), (float32)(r[1]), (float32)(r[2]) }
+	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
 	return ret, nil
 }
 
 //GetMaxAcceleration gets the max acceleration value from a phidget motion sensor
-func (p *PhidgetAccelerometer) GetMaxAcceleration() ([]float32, error) {
+func (p *PhidgetAccelerometer) GetMaxAcceleration() ([]float64, error) {
 	var r [3]C.double
 	cerr := C.PhidgetAccelerometer_getMaxAcceleration(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return nil, errors.New(p.getErrorDescription(cerr))
+		return nil, p.phidgetError(cerr)
 	}
-	var ret []float32 = []float32{ (float32)(r[0]), (float32)(r[1]), (float32)(r[2]) }
+	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
 	return ret, nil
 }
 
 //GetAccelerationChangeTrigger gets the acceleration from a phidget temperature sensor
-func (p *PhidgetAccelerometer) GetAccelerationChangeTrigger() (float32, error) {
+func (p *PhidgetAccelerometer) GetAccelerationChangeTrigger() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetAccelerometer_getAccelerationChangeTrigger(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetAccelerationChangeTrigger sets the acceleration trigger in the phidget temperature sensor
-func (p *PhidgetAccelerometer) SetAccelerationChangeTrigger(value float32) error {
-	cerr := C.PhidgetAccelerometer_setAccelerationChangeTrigger(p.handle, float32ToCdouble(value))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
+func (p *PhidgetAccelerometer) SetAccelerationChangeTrigger(value float64) error {
+	return p.phidgetError(C.PhidgetAccelerometer_setAccelerationChangeTrigger(p.handle, C.double(value)))
 }
 
 //GetMinAccelerationChangeTrigger sets the min acceleration trigger in the phidget temperature sensor
-func (p *PhidgetAccelerometer) GetMinAccelerationChangeTrigger() (float32, error) {
+func (p *PhidgetAccelerometer) GetMinAccelerationChangeTrigger() (float64, error) {
 	var r C.double
-	cerr := C.PhidgetAccelerometer_getMinAccelerationChangeTrigger(p.handle, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+	if cerr := C.PhidgetAccelerometer_getMinAccelerationChangeTrigger(p.handle, &r); cerr != C.EPHIDGET_OK {
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //GetMaxAccelerationChangeTrigger sets the min acceleration trigger in the phidget temperature sensor
-func (p *PhidgetAccelerometer) GetMaxAccelerationChangeTrigger() (float32, error) {
+func (p *PhidgetAccelerometer) GetMaxAccelerationChangeTrigger() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetAccelerometer_getMaxAccelerationChangeTrigger(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //GetAxisCount return the number of axis of the motion sensor
@@ -104,9 +98,9 @@ func (p *PhidgetAccelerometer) GetAxisCount() (int, error) {
 	var r C.int
 	cerr := C.PhidgetAccelerometer_getAxisCount(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cIntToint(r), nil
+	return int(r), nil
 }
 
 //GetDataInterval return the number of axis of the motion sensor
@@ -114,7 +108,7 @@ func (p *PhidgetAccelerometer) GetDataInterval() (uint32, error) {
 	var r C.uint32_t
 	cerr := C.PhidgetAccelerometer_getDataInterval(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
 	return (uint32)(r), nil
 }
@@ -123,7 +117,7 @@ func (p *PhidgetAccelerometer) GetDataInterval() (uint32, error) {
 func (p *PhidgetAccelerometer) SetDataInterval(value uint32) error {
 	cerr := C.PhidgetAccelerometer_setDataInterval(p.handle, (C.uint32_t)(value))
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }
@@ -133,7 +127,7 @@ func (p *PhidgetAccelerometer) GetMinDataInterval() (uint32, error) {
 	var r C.uint32_t
 	cerr := C.PhidgetAccelerometer_getMinDataInterval(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
 	return (uint32)(r), nil
 }
@@ -143,142 +137,20 @@ func (p *PhidgetAccelerometer) GetMaxDataInterval() (uint32, error) {
 	var r C.uint32_t
 	cerr := C.PhidgetAccelerometer_getMaxDataInterval(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
 	return (uint32)(r), nil
 }
 
 //SetOnAccelerationChangeHandler - interrupt for motion changes calls a function
-func (p *PhidgetAccelerometer) SetOnAccelerationChangeHandler(f func(Phidget, interface{}, []float32, float32), ctx interface{}) error {
+func (p *PhidgetAccelerometer) SetOnAccelerationChangeHandler(f func([]float64, float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough MotionPassthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetAccelerometer_setOnAccelerationChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetAccelerometer) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetAccelerometer) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget motion sensor's serial number
-func (p *PhidgetAccelerometer) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget motion sensor's hub port
-func (p *PhidgetAccelerometer) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget motion sensor's remote status
-func (p *PhidgetAccelerometer) GetIsRemote() (bool, error) {
-	//Cast MotionHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget motion sensor's serial number
-func (p *PhidgetAccelerometer) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget motion sensor's hub port
-func (p *PhidgetAccelerometer) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget motion sensor for attachment
-func (p *PhidgetAccelerometer) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetChannel sets a phidget motion sensor's channel port
-func (p *PhidgetAccelerometer) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget motion sensor's channel port
-func (p *PhidgetAccelerometer) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetAccelerometer) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetAccelerometer_delete((*C.PhidgetAccelerometerHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }

--- a/phidgets/accelerometer.go
+++ b/phidgets/accelerometer.go
@@ -10,8 +10,9 @@ void ccallback(void* handle, void* ctx, const double acceleration[3], double tim
 */
 import "C"
 import (
-	gopointer "github.com/mattn/go-pointer"
 	"unsafe"
+
+	gopointer "github.com/mattn/go-pointer"
 )
 
 //PhidgetAccelerometer is the struct that is a phidget motion sensor
@@ -153,4 +154,12 @@ func (p *PhidgetAccelerometer) SetOnAccelerationChangeHandler(f func([]float64, 
 		return p.phidgetError(cerr)
 	}
 	return nil
+}
+
+//Close - close the handle and delete it
+func (p *PhidgetAccelerometer) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetAccelerometer_delete(&p.handle))
 }

--- a/phidgets/accelerometer.go
+++ b/phidgets/accelerometer.go
@@ -34,8 +34,7 @@ func (p *PhidgetAccelerometer) GetAcceleration() ([]float64, error) {
 	if cerr != C.EPHIDGET_OK {
 		return nil, p.phidgetError(cerr)
 	}
-	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
-	return ret, nil
+	return []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}, nil
 }
 
 //GetMinAcceleration gets the min acceleration value from a phidget motion sensor
@@ -45,8 +44,7 @@ func (p *PhidgetAccelerometer) GetMinAcceleration() ([]float64, error) {
 	if cerr != C.EPHIDGET_OK {
 		return nil, p.phidgetError(cerr)
 	}
-	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
-	return ret, nil
+	return []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}, nil
 }
 
 //GetMaxAcceleration gets the max acceleration value from a phidget motion sensor
@@ -56,8 +54,7 @@ func (p *PhidgetAccelerometer) GetMaxAcceleration() ([]float64, error) {
 	if cerr != C.EPHIDGET_OK {
 		return nil, p.phidgetError(cerr)
 	}
-	var ret []float64 = []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}
-	return ret, nil
+	return []float64{(float64)(r[0]), (float64)(r[1]), (float64)(r[2])}, nil
 }
 
 //GetAccelerationChangeTrigger gets the acceleration from a phidget temperature sensor

--- a/phidgets/common.go
+++ b/phidgets/common.go
@@ -16,32 +16,24 @@ import (
 
 //Passthrough - Go struct that passes through the phidget context callback, giving us a Go phidget pointer and the function we should callback to
 type Passthrough struct {
-	f      func(Phidget, interface{}, float32)
-	ctx    interface{}
-	handle Phidget
+	f func(float64)
 }
 
-//MotionPassthrough - has more than one float32 value as a parameter
+//MotionPassthrough - has more than one float64 value as a parameter
 type MotionPassthrough struct {
-	f      func(Phidget, interface{}, []float32, float32)
-	ctx    interface{}
-	handle Phidget
+	f func([]float64, float64)
 }
 
-//SoundPassthrough - has more than one float32 value as a parameter
+//SoundPassthrough - has more than one float64 value as a parameter
 type SoundPassthrough struct {
-	f      func(Phidget, interface{}, float32, float32, float32, []float32)
-	ctx    interface{}
-	handle Phidget
+	f func(float64, float64, float64, []float64)
 }
 
 //export callback
 func callback(handle unsafe.Pointer, ctx unsafe.Pointer, value C.double) {
 	passthrough := gopointer.Restore(ctx).(Passthrough)
 	p2 := passthrough.f
-	c := passthrough.ctx
-	h := passthrough.handle
-	p2(h, c, cDoubleTofloat32(value))
+	p2(float64(value))
 }
 
 func carray2slice(array *C.double, len int) []C.double {
@@ -57,24 +49,17 @@ func carray2slice(array *C.double, len int) []C.double {
 func soundcallback(handle unsafe.Pointer, ctx unsafe.Pointer, dB C.double, dBA C.double, dBC C.double, octaves *C.double) {
 	passthrough := gopointer.Restore(ctx).(SoundPassthrough)
 	p2 := passthrough.f
-	c := passthrough.ctx
-	h := passthrough.handle
-	var slce []float32
+	var slce []float64
 	length := 10
 	cslce := carray2slice(octaves, length)
 	for i := 0; i < length; i++ {
-		slce = append(slce, cDoubleTofloat32(cslce[i]))
+		slce = append(slce, float64(cslce[i]))
 	}
 
-	p2(h, c, cDoubleTofloat32(dB), cDoubleTofloat32(dBA), cDoubleTofloat32(dBC), slce)
+	p2(float64(dB), float64(dBA), float64(dBC), slce)
 }
 
 //Common functions that convert different types for this package
-
-func float32ToCdouble(f float32) C.double {
-	return C.double(f)
-}
-
 func boolToCInt(b bool) C.int {
 	var r C.int
 	if b {
@@ -95,35 +80,6 @@ func intToBool(i int) bool {
 	return b
 }
 
-func intToCInt(i int) C.int {
-	var c C.int
-	c = (C.int)(i)
-	return c
-}
-
-func cIntToint(c C.int) int {
-	var i int
-	i = (int)(c)
-	return i
-}
-
 func cIntTobool(c C.int) bool {
-	i := cIntToint(c)
-	return intToBool(i)
-}
-
-func uintToCUInt(i uint) C.uint {
-	var c C.uint
-	c = (C.uint)(i)
-	return c
-}
-
-func cDoubleTofloat32(d C.double) float32 {
-	var f float32
-	f = (float32)(d)
-	return f
-}
-
-func stringToCCharArray(s string) *C.char {
-	return C.CString(s)
+	return c != 0
 }

--- a/phidgets/common.go
+++ b/phidgets/common.go
@@ -79,7 +79,3 @@ func intToBool(i int) bool {
 	}
 	return b
 }
-
-func cIntTobool(c C.int) bool {
-	return c != 0
-}

--- a/phidgets/current.go
+++ b/phidgets/current.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetCurrentInput is the struct that is a phidget current sensor
 type PhidgetCurrentInput struct {
-	Phidget
+	phidget
 	handle C.PhidgetCurrentInputHandle
 }
 
@@ -52,7 +52,7 @@ func (p *PhidgetCurrentInput) SetOnCurrentChangeHandler(f func(float64)) error {
 
 //Close - close the handle and delete it
 func (p *PhidgetCurrentInput) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetCurrentInput_delete(&p.handle))

--- a/phidgets/current.go
+++ b/phidgets/current.go
@@ -49,3 +49,11 @@ func (p *PhidgetCurrentInput) SetOnCurrentChangeHandler(f func(float64)) error {
 	}
 	return nil
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetCurrentInput) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetCurrentInput_delete(&p.handle))
+}

--- a/phidgets/current.go
+++ b/phidgets/current.go
@@ -10,8 +10,6 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,155 +17,35 @@ import (
 
 //PhidgetCurrentInput is the struct that is a phidget current sensor
 type PhidgetCurrentInput struct {
+	Phidget
 	handle C.PhidgetCurrentInputHandle
 }
 
 //Create creates a phidget current sensor
 func (p *PhidgetCurrentInput) Create() {
 	C.PhidgetCurrentInput_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the current from a phidget current sensor
-func (p *PhidgetCurrentInput) GetValue() (float32, error) {
+func (p *PhidgetCurrentInput) GetValue() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetCurrentInput_getCurrent(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetOnCurrentChangeHandler - interrupt for current changes calls a function
-func (p *PhidgetCurrentInput) SetOnCurrentChangeHandler(f func(Phidget, interface{}, float32), ctx interface{}) error {
+func (p *PhidgetCurrentInput) SetOnCurrentChangeHandler(f func(float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough Passthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetCurrentInput_setOnCurrentChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetCurrentInput) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetCurrentInput) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget current sensor's serial number
-func (p *PhidgetCurrentInput) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget current sensor's hub port
-func (p *PhidgetCurrentInput) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget current sensor's remote status
-func (p *PhidgetCurrentInput) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget current sensor's serial number
-func (p *PhidgetCurrentInput) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget current sensor's hub port
-func (p *PhidgetCurrentInput) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget current sensor for attachment
-func (p *PhidgetCurrentInput) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetChannel sets a phidget current sensor's channel port
-func (p *PhidgetCurrentInput) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget current sensor's channel port
-func (p *PhidgetCurrentInput) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetCurrentInput) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetCurrentInput_delete((*C.PhidgetCurrentInputHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }

--- a/phidgets/humidity.go
+++ b/phidgets/humidity.go
@@ -49,3 +49,11 @@ func (p *PhidgetHumiditySensor) SetOnHumidityChangeHandler(f func(float64)) erro
 	}
 	return nil
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetHumiditySensor) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetHumiditySensor_delete(&p.handle))
+}

--- a/phidgets/humidity.go
+++ b/phidgets/humidity.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetHumiditySensor is the struct that is a phidget humidity sensor
 type PhidgetHumiditySensor struct {
-	Phidget
+	phidget
 	handle C.PhidgetHumiditySensorHandle
 }
 
@@ -52,7 +52,7 @@ func (p *PhidgetHumiditySensor) SetOnHumidityChangeHandler(f func(float64)) erro
 
 //Close - close the handle and delete it
 func (p *PhidgetHumiditySensor) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetHumiditySensor_delete(&p.handle))

--- a/phidgets/lcd.go
+++ b/phidgets/lcd.go
@@ -27,7 +27,10 @@ func (p *PhidgetLCD) Create() {
 
 //SetText sets the lcd text
 func (p *PhidgetLCD) SetText(text string) error {
-	if cerr := C.PhidgetLCD_writeText(p.handle, C.FONT_6x12, 40, 25, C.CString(text)); cerr != C.EPHIDGET_OK {
+	str := C.CString(text)
+	cerr := C.PhidgetLCD_writeText(p.handle, C.FONT_6x12, 40, 25, str)
+	C.free(unsafe.Pointer(str))
+	if cerr != C.EPHIDGET_OK {
 		return p.phidgetError(cerr)
 	}
 	return p.phidgetError(C.PhidgetLCD_flush(p.handle))

--- a/phidgets/lcd.go
+++ b/phidgets/lcd.go
@@ -37,3 +37,11 @@ func (p *PhidgetLCD) SetText(text string) error {
 func (p *PhidgetLCD) SetBacklight(brightness float32) error {
 	return p.phidgetError(C.PhidgetLCD_setBacklight(p.handle, C.double(brightness)))
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetLCD) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetLCD_delete(&p.handle))
+}

--- a/phidgets/lcd.go
+++ b/phidgets/lcd.go
@@ -10,148 +10,30 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 )
 
 //PhidgetLCD is the struct that is a phidget lcd sensor
 type PhidgetLCD struct {
+	Phidget
 	handle C.PhidgetLCDHandle
 }
 
 //Create creates a phidget lcd sensor
 func (p *PhidgetLCD) Create() {
 	C.PhidgetLCD_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //SetText sets the lcd text
-func (p *PhidgetLCD) SetText(text string) {
-	C.PhidgetLCD_writeText(p.handle, C.FONT_6x12, 40, 25, stringToCCharArray(text))
-	C.PhidgetLCD_flush(p.handle)
+func (p *PhidgetLCD) SetText(text string) error {
+	if cerr := C.PhidgetLCD_writeText(p.handle, C.FONT_6x12, 40, 25, C.CString(text)); cerr != C.EPHIDGET_OK {
+		return p.phidgetError(cerr)
+	}
+	return p.phidgetError(C.PhidgetLCD_flush(p.handle))
 }
 
 //SetBacklight - sets the backlight value
-func (p *PhidgetLCD) SetBacklight(brightness float32) {
-	C.PhidgetLCD_setBacklight(p.handle, float32ToCdouble(brightness))
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetLCD) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetLCD) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget lcd sensor's serial number
-func (p *PhidgetLCD) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget lcd sensor's hub port
-func (p *PhidgetLCD) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget lcd sensor's remote status
-func (p *PhidgetLCD) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget lcd sensor's serial number
-func (p *PhidgetLCD) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget lcd sensor's hub port
-func (p *PhidgetLCD) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget lcd sensor for attachment
-func (p *PhidgetLCD) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetChannel sets a phidget lcd sensor's channel port
-func (p *PhidgetLCD) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget lcd sensor's channel port
-func (p *PhidgetLCD) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetLCD) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetLCD_delete((*C.PhidgetLCDHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
+func (p *PhidgetLCD) SetBacklight(brightness float32) error {
+	return p.phidgetError(C.PhidgetLCD_setBacklight(p.handle, C.double(brightness)))
 }

--- a/phidgets/lcd.go
+++ b/phidgets/lcd.go
@@ -15,7 +15,7 @@ import (
 
 //PhidgetLCD is the struct that is a phidget lcd sensor
 type PhidgetLCD struct {
-	Phidget
+	phidget
 	handle C.PhidgetLCDHandle
 }
 
@@ -43,7 +43,7 @@ func (p *PhidgetLCD) SetBacklight(brightness float32) error {
 
 //Close - close the handle and delete it
 func (p *PhidgetLCD) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetLCD_delete(&p.handle))

--- a/phidgets/light.go
+++ b/phidgets/light.go
@@ -10,8 +10,6 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,155 +17,35 @@ import (
 
 //PhidgetLightSensor is the struct that is a phidget lumenance sensor
 type PhidgetLightSensor struct {
+	Phidget
 	handle C.PhidgetLightSensorHandle
 }
 
 //Create creates a phidget lumenance sensor
 func (p *PhidgetLightSensor) Create() {
 	C.PhidgetLightSensor_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the lumenance from a phidget lumenance sensor
-func (p *PhidgetLightSensor) GetValue() (float32, error) {
+func (p *PhidgetLightSensor) GetValue() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetLightSensor_getIlluminance(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetOnIlluminanceChangeHandler - interrupt for illumiance changes calls a function
-func (p *PhidgetLightSensor) SetOnIlluminanceChangeHandler(f func(Phidget, interface{}, float32), ctx interface{}) error {
+func (p *PhidgetLightSensor) SetOnIlluminanceChangeHandler(f func(float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough Passthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetLightSensor_setOnIlluminanceChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetLightSensor) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetLightSensor) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget light sensor's serial number
-func (p *PhidgetLightSensor) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget light sensor's hub port
-func (p *PhidgetLightSensor) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetHubPort gets a phidget light sensor's hub port
-func (p *PhidgetLightSensor) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//SetChannel sets a phidget light sensor's channel port
-func (p *PhidgetLightSensor) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget light sensor's channel port
-func (p *PhidgetLightSensor) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetIsRemote gets a phidget light sensor's remote status
-func (p *PhidgetLightSensor) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget light sensor's serial number
-func (p *PhidgetLightSensor) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget light sensor for attachment
-func (p *PhidgetLightSensor) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetLightSensor) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetLightSensor_delete((*C.PhidgetLightSensorHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }

--- a/phidgets/light.go
+++ b/phidgets/light.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetLightSensor is the struct that is a phidget lumenance sensor
 type PhidgetLightSensor struct {
-	Phidget
+	phidget
 	handle C.PhidgetLightSensorHandle
 }
 
@@ -52,7 +52,7 @@ func (p *PhidgetLightSensor) SetOnIlluminanceChangeHandler(f func(float64)) erro
 
 //Close - close the handle and delete it
 func (p *PhidgetLightSensor) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetLightSensor_delete(&p.handle))

--- a/phidgets/light.go
+++ b/phidgets/light.go
@@ -49,3 +49,11 @@ func (p *PhidgetLightSensor) SetOnIlluminanceChangeHandler(f func(float64)) erro
 	}
 	return nil
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetLightSensor) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetLightSensor_delete(&p.handle))
+}

--- a/phidgets/phidget.go
+++ b/phidgets/phidget.go
@@ -127,5 +127,5 @@ func (p *phidget) GetChannelClassName() (string, error) {
 
 //SetIsHubPortDevice sets a phidget sensor as a remote device
 func (p *phidget) SetIsHubPortDevice(b bool) error {
- 	return p.phidgetError(C.Phidget_setIsHubPortDevice(p.handle, boolToCInt(b)))
- }
+	return p.phidgetError(C.Phidget_setIsHubPortDevice(p.handle, boolToCInt(b)))
+}

--- a/phidgets/phidget.go
+++ b/phidgets/phidget.go
@@ -20,6 +20,8 @@ type Phidget struct {
 	class  string
 }
 
+//rawHandle updates the base Phidget object with a handle from another object
+//This must be called when a new Phidget object is created of a differing class
 func (p *Phidget) rawHandle(handle unsafe.Pointer) {
 	p.handle = (*C.struct__Phidget)(handle)
 }
@@ -45,6 +47,7 @@ func (p *Phidget) phidgetError(cerr C.PhidgetReturnCode) error {
 	return errors.New(C.GoString(errorString))
 }
 
+//SetIsRemote sets a phidget sensor as a remote device
 func (p *Phidget) SetIsRemote(b bool) error {
 	return p.phidgetError(C.Phidget_setIsRemote(p.handle, boolToCInt(b)))
 }
@@ -80,7 +83,7 @@ func (p *Phidget) GetIsRemote() (bool, error) {
 	if cerr := C.Phidget_getIsRemote(p.handle, &r); cerr != C.EPHIDGET_OK {
 		return false, p.phidgetError(cerr)
 	}
-	return cIntTobool(r), nil
+	return r != 0, nil
 }
 
 //GetDeviceSerialNumber gets a phidget motion sensor's serial number

--- a/phidgets/phidget.go
+++ b/phidgets/phidget.go
@@ -15,19 +15,33 @@ import (
 )
 
 //Phidget - general phidget interface that all phidgets are derived from (for ease of type management)
-type Phidget struct {
+type phidget struct {
 	handle C.PhidgetHandle
 	class  string
 }
 
+type Phidget interface {
+	OpenWaitForAttachment(timeout time.Duration) error
+	SetIsRemote(b bool) error
+	SetDeviceSerialNumber(serial int) error
+	SetHubPort(port int) error
+	GetHubPort() (int, error)
+	SetChannel(port int) error
+	GetIsRemote() (bool, error)
+	SetIsHubPortDevice(b bool) error
+	GetDeviceSerialNumber() (int, error)
+	Close() error
+	GetChannelClassName() (string, error)
+}
+
 //rawHandle updates the base Phidget object with a handle from another object
 //This must be called when a new Phidget object is created of a differing class
-func (p *Phidget) rawHandle(handle unsafe.Pointer) {
+func (p *phidget) rawHandle(handle unsafe.Pointer) {
 	p.handle = (*C.struct__Phidget)(handle)
 }
 
 //OpenWaitForAttachment opens a phidget and waits for it to be available on the bus
-func (p *Phidget) OpenWaitForAttachment(timeout time.Duration) error {
+func (p *phidget) OpenWaitForAttachment(timeout time.Duration) error {
 	if cerr := C.Phidget_openWaitForAttachment(p.handle, C.uint(timeout.Milliseconds())); cerr != C.EPHIDGET_OK {
 		return p.phidgetError(cerr)
 	}
@@ -35,7 +49,7 @@ func (p *Phidget) OpenWaitForAttachment(timeout time.Duration) error {
 	return nil
 }
 
-func (p *Phidget) phidgetError(cerr C.PhidgetReturnCode) error {
+func (p *phidget) phidgetError(cerr C.PhidgetReturnCode) error {
 	if cerr == C.EPHIDGET_OK {
 		return nil
 	}
@@ -48,23 +62,23 @@ func (p *Phidget) phidgetError(cerr C.PhidgetReturnCode) error {
 }
 
 //SetIsRemote sets a phidget sensor as a remote device
-func (p *Phidget) SetIsRemote(b bool) error {
+func (p *phidget) SetIsRemote(b bool) error {
 	return p.phidgetError(C.Phidget_setIsRemote(p.handle, boolToCInt(b)))
 }
 
 //SetDeviceSerialNumber sets the serial number to use.
 //This must be called before calling OpenWaitForAttachment
-func (p *Phidget) SetDeviceSerialNumber(serial int) error {
+func (p *phidget) SetDeviceSerialNumber(serial int) error {
 	return p.phidgetError(C.Phidget_setDeviceSerialNumber(p.handle, C.int(serial)))
 }
 
 //SetHubPort sets a phidget's hub port
-func (p *Phidget) SetHubPort(port int) error {
+func (p *phidget) SetHubPort(port int) error {
 	return p.phidgetError(C.Phidget_setHubPort(p.handle, C.int(port)))
 }
 
 //GetHubPort gets a phidget's hub port
-func (p *Phidget) GetHubPort() (int, error) {
+func (p *phidget) GetHubPort() (int, error) {
 	var r C.int
 	if cerr := C.Phidget_getHubPort(p.handle, &r); cerr != C.EPHIDGET_OK {
 		return 0, p.phidgetError(cerr)
@@ -73,12 +87,12 @@ func (p *Phidget) GetHubPort() (int, error) {
 }
 
 //SetChannel sets a phidget motion sensor's channel port
-func (p *Phidget) SetChannel(port int) error {
+func (p *phidget) SetChannel(port int) error {
 	return p.phidgetError(C.Phidget_setChannel(p.handle, C.int(port)))
 }
 
 //GetIsRemote gets a phidget's remote status
-func (p *Phidget) GetIsRemote() (bool, error) {
+func (p *phidget) GetIsRemote() (bool, error) {
 	var r C.int
 	if cerr := C.Phidget_getIsRemote(p.handle, &r); cerr != C.EPHIDGET_OK {
 		return false, p.phidgetError(cerr)
@@ -87,7 +101,7 @@ func (p *Phidget) GetIsRemote() (bool, error) {
 }
 
 //GetDeviceSerialNumber gets a phidget motion sensor's serial number
-func (p *Phidget) GetDeviceSerialNumber() (int, error) {
+func (p *phidget) GetDeviceSerialNumber() (int, error) {
 	var r C.int
 	cerr := C.Phidget_getDeviceSerialNumber(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
@@ -97,12 +111,12 @@ func (p *Phidget) GetDeviceSerialNumber() (int, error) {
 }
 
 //Close - close the handle and delete it
-func (p *Phidget) Close() error {
+func (p *phidget) Close() error {
 	return p.phidgetError(C.Phidget_close(p.handle))
 }
 
 //GetChannelClassName gets the name of the channel class the channel belongs to.
-func (p *Phidget) GetChannelClassName() (string, error) {
+func (p *phidget) GetChannelClassName() (string, error) {
 	var name *C.char
 	cerr := C.Phidget_getChannelClassName(p.handle, &name)
 	if cerr != C.EPHIDGET_OK {
@@ -110,3 +124,8 @@ func (p *Phidget) GetChannelClassName() (string, error) {
 	}
 	return C.GoString(name), nil
 }
+
+//SetIsHubPortDevice sets a phidget sensor as a remote device
+func (p *phidget) SetIsHubPortDevice(b bool) error {
+ 	return p.phidgetError(C.Phidget_setIsHubPortDevice(p.handle, boolToCInt(b)))
+ }

--- a/phidgets/phidget.go
+++ b/phidgets/phidget.go
@@ -21,6 +21,7 @@ type phidget struct {
 }
 
 type Phidget interface {
+	Create()
 	OpenWaitForAttachment(timeout time.Duration) error
 	SetIsRemote(b bool) error
 	SetDeviceSerialNumber(serial int) error

--- a/phidgets/phidgetnet.go
+++ b/phidgets/phidgetnet.go
@@ -7,8 +7,17 @@ package phidgets
 #include <phidget22.h>
 */
 import "C"
+import "unsafe"
 
 //AddServer adds a
 func AddServer(serverName string, address string, port int, password string, flags int) {
-	C.PhidgetNet_addServer(C.CString(serverName), C.CString(address), C.int(port), C.CString(password), C.int(flags))
+	serverC := C.CString(serverName)
+	addressC := C.CString(address)
+	passwordC := C.CString(password)
+
+	C.PhidgetNet_addServer(serverC, addressC, C.int(port), passwordC, C.int(flags))
+
+	C.free(unsafe.Pointer(serverC))
+	C.free(unsafe.Pointer(addressC))
+	C.free(unsafe.Pointer(passwordC))
 }

--- a/phidgets/phidgetnet.go
+++ b/phidgets/phidgetnet.go
@@ -10,5 +10,5 @@ import "C"
 
 //AddServer adds a
 func AddServer(serverName string, address string, port int, password string, flags int) {
-	C.PhidgetNet_addServer(C.CString(serverName), C.CString(address), intToCInt(port), C.CString(password), intToCInt(flags))
+	C.PhidgetNet_addServer(C.CString(serverName), C.CString(address), C.int(port), C.CString(password), C.int(flags))
 }

--- a/phidgets/sound.go
+++ b/phidgets/sound.go
@@ -10,8 +10,6 @@ void csoundcallback(void* handle, void* ctx, double dB, double dBA, double dBC, 
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,164 +17,40 @@ import (
 
 //PhidgetSoundSensor is the struct that is a phidget sound sensor
 type PhidgetSoundSensor struct {
+	Phidget
 	handle C.PhidgetSoundSensorHandle
 }
 
 //Create creates a phidget sound sensor
 func (p *PhidgetSoundSensor) Create() {
 	C.PhidgetSoundSensor_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the decibels from a phidget sound sensor
-func (p *PhidgetSoundSensor) GetValue() (float32, error) {
+func (p *PhidgetSoundSensor) GetValue() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetSoundSensor_getdB(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetSPLChangeTrigger sets the interrupt trigger point
-func (p *PhidgetSoundSensor) SetSPLChangeTrigger(dBs float32) error {
-	cerr := C.PhidgetSoundSensor_setSPLChangeTrigger(p.handle, float32ToCdouble(dBs))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
+func (p *PhidgetSoundSensor) SetSPLChangeTrigger(dBs float64) error {
+	return p.phidgetError(C.PhidgetSoundSensor_setSPLChangeTrigger(p.handle, C.double(dBs)))
 }
 
 //SetOnSPLChangeHandler - interrupt for sound changes calls a function
-func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(Phidget, interface{}, float32, float32, float32, []float32), ctx interface{}) error {
+func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(float64, float64, float64, []float64), ctx interface{}) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough SoundPassthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetSoundSensor_setOnSPLChangeHandler(p.handle, (C.sound_callback_fcn)(unsafe.Pointer(C.csoundcallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetSoundSensor) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetSoundSensor) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget sound sensor's serial number
-func (p *PhidgetSoundSensor) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget sound sensor's hub port
-func (p *PhidgetSoundSensor) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget sound sensor's remote status
-func (p *PhidgetSoundSensor) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget sound sensor's serial number
-func (p *PhidgetSoundSensor) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget sound sensor's hub port
-func (p *PhidgetSoundSensor) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//SetChannel sets a phidget sound sensor's channel port
-func (p *PhidgetSoundSensor) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget sound sensor's channel port
-func (p *PhidgetSoundSensor) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget sound sensor for attachment
-func (p *PhidgetSoundSensor) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetSoundSensor) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetSoundSensor_delete((*C.PhidgetSoundSensorHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }

--- a/phidgets/sound.go
+++ b/phidgets/sound.go
@@ -54,3 +54,11 @@ func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(float64, float64, floa
 	}
 	return nil
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetSoundSensor) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetSoundSensor_delete(&p.handle))
+}

--- a/phidgets/sound.go
+++ b/phidgets/sound.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetSoundSensor is the struct that is a phidget sound sensor
 type PhidgetSoundSensor struct {
-	Phidget
+	phidget
 	handle C.PhidgetSoundSensorHandle
 }
 
@@ -43,7 +43,7 @@ func (p *PhidgetSoundSensor) SetSPLChangeTrigger(dBs float64) error {
 }
 
 //SetOnSPLChangeHandler - interrupt for sound changes calls a function
-func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(float64, float64, float64, []float64), ctx interface{}) error {
+func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(float64, float64, float64, []float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough SoundPassthrough
 	passthrough.f = f
@@ -57,7 +57,7 @@ func (p *PhidgetSoundSensor) SetOnSPLChangeHandler(f func(float64, float64, floa
 
 //Close - close the handle and delete it
 func (p *PhidgetSoundSensor) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetSoundSensor_delete(&p.handle))

--- a/phidgets/temperature.go
+++ b/phidgets/temperature.go
@@ -10,8 +10,6 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,155 +17,38 @@ import (
 
 //PhidgetTemperatureSensor is the struct that is a phidget temperature sensor
 type PhidgetTemperatureSensor struct {
+	Phidget
 	handle C.PhidgetTemperatureSensorHandle
 }
 
 //Create creates a phidget temperature sensor
 func (p *PhidgetTemperatureSensor) Create() {
 	C.PhidgetTemperatureSensor_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the temperature from a phidget temperature sensor
-func (p *PhidgetTemperatureSensor) GetValue() (float32, error) {
+func (p *PhidgetTemperatureSensor) GetValue() (float64, error) {
 	var r C.double
-	cerr := C.PhidgetTemperatureSensor_getTemperature(p.handle, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+	if cerr := C.PhidgetTemperatureSensor_getTemperature(p.handle, &r); cerr != C.EPHIDGET_OK {
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetOnTemperatureChangeHandler - interrupt for temperature changes calls a function
-func (p *PhidgetTemperatureSensor) SetOnTemperatureChangeHandler(f func(Phidget, interface{}, float32), ctx interface{}) error {
+func (p *PhidgetTemperatureSensor) SetOnTemperatureChangeHandler(f func(float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough Passthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetTemperatureSensor_setOnTemperatureChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
+	return p.phidgetError(cerr)
 }
 
-//Common to all derived phidgets
-
-func (p *PhidgetTemperatureSensor) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetTemperatureSensor) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget lcd sensor's serial number
-func (p *PhidgetTemperatureSensor) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget lcd sensor's hub port
-func (p *PhidgetTemperatureSensor) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget lcd sensor's remote status
-func (p *PhidgetTemperatureSensor) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget lcd sensor's serial number
-func (p *PhidgetTemperatureSensor) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget lcd sensor's hub port
-func (p *PhidgetTemperatureSensor) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget lcd sensor for attachment
-func (p *PhidgetTemperatureSensor) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetChannel sets a phidget temperature sensor's channel port
-func (p *PhidgetTemperatureSensor) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget temperature sensor's channel port
-func (p *PhidgetTemperatureSensor) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//Close - close the handle and delete it
 func (p *PhidgetTemperatureSensor) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+	if err := p.Phidget.Close(); err != nil {
+		return err
 	}
-	cerr = C.PhidgetTemperatureSensor_delete((*C.PhidgetTemperatureSensorHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
+	return p.phidgetError(C.PhidgetTemperatureSensor_delete(&p.handle))
 }

--- a/phidgets/temperature.go
+++ b/phidgets/temperature.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetTemperatureSensor is the struct that is a phidget temperature sensor
 type PhidgetTemperatureSensor struct {
-	Phidget
+	phidget
 	handle C.PhidgetTemperatureSensorHandle
 }
 
@@ -47,7 +47,7 @@ func (p *PhidgetTemperatureSensor) SetOnTemperatureChangeHandler(f func(float64)
 }
 
 func (p *PhidgetTemperatureSensor) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetTemperatureSensor_delete(&p.handle))

--- a/phidgets/voltageinput.go
+++ b/phidgets/voltageinput.go
@@ -49,3 +49,11 @@ func (p *PhidgetVoltageInput) SetOnVoltageChangeHandler(f func(float64)) error {
 	}
 	return nil
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetVoltageInput) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetVoltageInput_delete(&p.handle))
+}

--- a/phidgets/voltageinput.go
+++ b/phidgets/voltageinput.go
@@ -10,8 +10,6 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 */
 import "C"
 import (
-	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,155 +17,35 @@ import (
 
 //PhidgetVoltageInput is the struct that is a phidget voltageinput sensor
 type PhidgetVoltageInput struct {
+	Phidget
 	handle C.PhidgetVoltageInputHandle
 }
 
 //Create creates a phidget voltageinput sensor
 func (p *PhidgetVoltageInput) Create() {
 	C.PhidgetVoltageInput_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the voltageinput from a phidget voltageinput sensor
-func (p *PhidgetVoltageInput) GetValue() (float32, error) {
+func (p *PhidgetVoltageInput) GetValue() (float64, error) {
 	var r C.double
 	cerr := C.PhidgetVoltageInput_getVoltage(p.handle, &r)
 	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetOnVoltageChangeHandler - voltage input for temperature changes calls a function
-func (p *PhidgetVoltageInput) SetOnVoltageChangeHandler(f func(Phidget, interface{}, float32), ctx interface{}) error {
+func (p *PhidgetVoltageInput) SetOnVoltageChangeHandler(f func(float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough Passthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetVoltageInput_setOnVoltageChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetVoltageInput) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetVoltageInput) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget voltageinput sensor's serial number
-func (p *PhidgetVoltageInput) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget voltageinput sensor's hub port
-func (p *PhidgetVoltageInput) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget voltageinput sensor's remote status
-func (p *PhidgetVoltageInput) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget voltageinput sensor's serial number
-func (p *PhidgetVoltageInput) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget voltageinput sensor's hub port
-func (p *PhidgetVoltageInput) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//SetChannel sets a phidget voltageinput sensor's channel port
-func (p *PhidgetVoltageInput) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget voltageinput sensor's channel port
-func (p *PhidgetVoltageInput) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget voltageinput sensor for attachment
-func (p *PhidgetVoltageInput) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetVoltageInput) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetVoltageInput_delete((*C.PhidgetVoltageInputHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }

--- a/phidgets/voltageinput.go
+++ b/phidgets/voltageinput.go
@@ -17,7 +17,7 @@ import (
 
 //PhidgetVoltageInput is the struct that is a phidget voltageinput sensor
 type PhidgetVoltageInput struct {
-	Phidget
+	phidget
 	handle C.PhidgetVoltageInputHandle
 }
 
@@ -52,7 +52,7 @@ func (p *PhidgetVoltageInput) SetOnVoltageChangeHandler(f func(float64)) error {
 
 //Close - close the handle and delete it
 func (p *PhidgetVoltageInput) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetVoltageInput_delete(&p.handle))

--- a/phidgets/voltageinputratio.go
+++ b/phidgets/voltageinputratio.go
@@ -11,7 +11,6 @@ void ccallback(void* handle, void* ctx, double b);  // Forward declaration.
 import "C"
 import (
 	"errors"
-	"reflect"
 	"unsafe"
 
 	gopointer "github.com/mattn/go-pointer"
@@ -19,180 +18,47 @@ import (
 
 //PhidgetVoltageRatioInput is the struct that is a phidget voltageinputratio sensor
 type PhidgetVoltageRatioInput struct {
+	Phidget
 	handle C.PhidgetVoltageRatioInputHandle
 }
 
 //Create creates a phidget voltageinputratio sensor
 func (p *PhidgetVoltageRatioInput) Create() {
 	C.PhidgetVoltageRatioInput_create(&p.handle)
+	p.rawHandle(unsafe.Pointer(p.handle))
 }
 
 //GetValue gets the voltageinputratio from a phidget voltageinputratio sensor
-func (p *PhidgetVoltageRatioInput) GetValue() (float32, error) {
+func (p *PhidgetVoltageRatioInput) GetValue() (float64, error) {
 	var r C.double
-	cerr := C.PhidgetVoltageRatioInput_getVoltageRatio(p.handle, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
+	if cerr := C.PhidgetVoltageRatioInput_getVoltageRatio(p.handle, &r); cerr != C.EPHIDGET_OK {
+		return 0, p.phidgetError(cerr)
 	}
-	return cDoubleTofloat32(r), nil
+	return float64(r), nil
 }
 
 //SetOnVoltageRatioChangeHandler - voltage input changes calls a function
-func (p *PhidgetVoltageRatioInput) SetOnVoltageRatioChangeHandler(f func(Phidget, interface{}, float32), ctx interface{}) error {
+func (p *PhidgetVoltageRatioInput) SetOnVoltageRatioChangeHandler(f func(float64)) error {
 	//make a c function pointer to a go function pointer and pass it through the phidget context
 	var passthrough Passthrough
 	passthrough.f = f
-	passthrough.ctx = ctx
-	passthrough.handle = p
 	pt := gopointer.Save(passthrough)
 	cerr := C.PhidgetVoltageRatioInput_setOnVoltageRatioChangeHandler(p.handle, (C.callback_fcn)(unsafe.Pointer(C.ccallback)), pt)
 	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//Common to all derived phidgets
-
-func (p *PhidgetVoltageRatioInput) getErrorDescription(cerr C.PhidgetReturnCode) string {
-	var errorString *C.char
-	C.Phidget_getErrorDescription(cerr, &errorString)
-	//Get the name of our class
-	t := reflect.TypeOf(p)
-	return t.Elem().Name() + ": " + C.GoString(errorString)
-}
-
-//SetIsRemote sets a phidget sensor as a remote device
-func (p *PhidgetVoltageRatioInput) SetIsRemote(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsRemote(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetIsHubPortDevice sets a phidget sensor as a remote device
-func (p *PhidgetVoltageRatioInput) SetIsHubPortDevice(b bool) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setIsHubPortDevice(h, boolToCInt(b))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-
-}
-
-//SetDeviceSerialNumber sets a phidget voltageinputratio sensor's serial number
-func (p *PhidgetVoltageRatioInput) SetDeviceSerialNumber(serial int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setDeviceSerialNumber(h, intToCInt(serial))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetHubPort sets a phidget voltageinputratio sensor's hub port
-func (p *PhidgetVoltageRatioInput) SetHubPort(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setHubPort(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetIsRemote gets a phidget voltageinputratio sensor's remote status
-func (p *PhidgetVoltageRatioInput) GetIsRemote() (bool, error) {
-	//Cast TemperatureHandle to PhidgetHandle
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getIsRemote(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return false, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntTobool(r), nil
-}
-
-//GetDeviceSerialNumber gets a phidget voltageinputratio sensor's serial number
-func (p *PhidgetVoltageRatioInput) GetDeviceSerialNumber() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getDeviceSerialNumber(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//GetHubPort gets a phidget voltageinputratio sensor's hub port
-func (p *PhidgetVoltageRatioInput) GetHubPort() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getHubPort(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//OpenWaitForAttachment opens a phidget voltageinputratio sensor for attachment
-func (p *PhidgetVoltageRatioInput) OpenWaitForAttachment(timeout uint) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_openWaitForAttachment(h, uintToCUInt(timeout))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//SetChannel sets a phidget voltageinputratio sensor's channel port
-func (p *PhidgetVoltageRatioInput) SetChannel(port int) error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_setChannel(h, intToCInt(port))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	return nil
-}
-
-//GetChannel gets a phidget voltageinputratio sensor's channel port
-func (p *PhidgetVoltageRatioInput) GetChannel() (int, error) {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	var r C.int
-	cerr := C.Phidget_getChannel(h, &r)
-	if cerr != C.EPHIDGET_OK {
-		return 0, errors.New(p.getErrorDescription(cerr))
-	}
-	return cIntToint(r), nil
-}
-
-//Close - close the handle and delete it
-func (p *PhidgetVoltageRatioInput) Close() error {
-	h := (*C.struct__Phidget)(unsafe.Pointer(p.handle))
-	cerr := C.Phidget_close(h)
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
-	}
-	cerr = C.PhidgetVoltageRatioInput_delete((*C.PhidgetVoltageRatioInputHandle)(&p.handle))
-	if cerr != C.EPHIDGET_OK {
-		return errors.New(p.getErrorDescription(cerr))
+		return p.phidgetError(cerr)
 	}
 	return nil
 }
 
 //SetSensorType - Specific to a voltageinputratio - setting the proper sensor type
-func (p *PhidgetVoltageRatioInput) SetSensorType(sensorType string) {
+func (p *PhidgetVoltageRatioInput) SetSensorType(sensorType string) error {
 	//TODO: need a better way to select a voltage ratio input sensor type by bringing the enum out to go world
 	var cSensor C.PhidgetVoltageRatioInput_SensorType
 	switch sensorType {
 	case "SENSOR_TYPE_1122_DC":
 		cSensor = C.SENSOR_TYPE_1122_DC
 	default:
-		panic("Unknown sensorType: " + sensorType + ". Please add it to the mapping switch in voltageinputratio.go")
+		return errors.New("Unknown sensorType: " + sensorType + ". Please add it to the mapping switch in voltageinputratio.go")
 	}
-	cSensorType := C.PhidgetVoltageRatioInput_SensorType(cSensor)
-	C.PhidgetVoltageRatioInput_setSensorType(p.handle, cSensorType)
+	return p.phidgetError(C.PhidgetVoltageRatioInput_setSensorType(p.handle, cSensor))
 }

--- a/phidgets/voltageinputratio.go
+++ b/phidgets/voltageinputratio.go
@@ -62,3 +62,11 @@ func (p *PhidgetVoltageRatioInput) SetSensorType(sensorType string) error {
 	}
 	return p.phidgetError(C.PhidgetVoltageRatioInput_setSensorType(p.handle, cSensor))
 }
+
+//Close - close the handle and delete it
+func (p *PhidgetVoltageRatioInput) Close() error {
+	if err := p.Phidget.Close(); err != nil {
+		return err
+	}
+	return p.phidgetError(C.PhidgetVoltageRatioInput_delete(&p.handle))
+}

--- a/phidgets/voltageinputratio.go
+++ b/phidgets/voltageinputratio.go
@@ -18,7 +18,7 @@ import (
 
 //PhidgetVoltageRatioInput is the struct that is a phidget voltageinputratio sensor
 type PhidgetVoltageRatioInput struct {
-	Phidget
+	phidget
 	handle C.PhidgetVoltageRatioInputHandle
 }
 
@@ -65,7 +65,7 @@ func (p *PhidgetVoltageRatioInput) SetSensorType(sensorType string) error {
 
 //Close - close the handle and delete it
 func (p *PhidgetVoltageRatioInput) Close() error {
-	if err := p.Phidget.Close(); err != nil {
+	if err := p.phidget.Close(); err != nil {
 		return err
 	}
 	return p.phidgetError(C.PhidgetVoltageRatioInput_delete(&p.handle))


### PR DESCRIPTION
In the process of doing this there are a couple of other API adjustments as well:
- Moving from float32 -> float64. Phidgets API returns C.double, which is 64-bit
- Removing context & phidget from callbacks. This is required in C because otherwise there is no way of getting context into callbacks. But in Go we can use anonymous functions to capture context, so this feels more idiomatic to me